### PR TITLE
Switch to groue/GRMustache.swift 2.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,6 @@ let package = Package(
     dependencies: [.Package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", majorVersion: 1, minor: 0)])
 
 #if os(OSX)
-    package.dependencies.append(.Package(url: "https://github.com/IBM-Swift/GRMustache.swift.git",
-                                         majorVersion: 1, minor: 3))
+    package.dependencies.append(.Package(url: "https://github.com/groue/GRMustache.swift.git",
+                                         majorVersion: 2, minor: 0))
 #endif

--- a/Sources/KituraMustacheTemplateEngine.swift
+++ b/Sources/KituraMustacheTemplateEngine.swift
@@ -28,7 +28,7 @@ public class MustacheTemplateEngine: TemplateEngine {
         return "support for GRMustache not yet implemented on Linux"
         #else
         let template = try Template(path: filePath)
-        return try template.render(with: Box(context))
+        return try template.render(context)
         #endif
     }
 }


### PR DESCRIPTION
Hello,

As recommended by @lroseblade in https://github.com/IBM-Swift/Kitura/issues/814, here is a pull request to replace IBM-Swift/GRMustache.swift with groue/GRMustache.swift, which has been updated for Swift 3 in its [version 2.0.0](https://github.com/groue/GRMustache.swift/blob/master/CHANGELOG.md#v200).

For a (simple) demo of the integration of the new GRMustache with Kitura, please see https://github.com/groue/GRMustacheKituraDemo.

This would imply some update in the Kitura documentation:

- https://github.com/IBM-Swift/Kitura/wiki/Use-template-engines-with-Kitura
- http://www.kitura.io/en/resources/tutorials/templating.html

CC @vadimeisenbergibm, who has been maintaining https://github.com/IBM-Swift/GRMustache.swift for a long time.