### PR TITLE
Add travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# Travis CI build file for Kitura-MustacheTemplateEngine.
+# Kitura runs on OS X and Linux (Ubuntu v14.04).
+
+# whitelist (branches that should be built)
+branches:
+  only:
+    - master
+    - develop
+    - /^issue.*$/
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: osx
+      osx_image: xcode9.2
+      sudo: required
+before_install:
+  - git clone https://github.com/IBM-Swift/Package-Builder.git
+
+script:
+- ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR


### PR DESCRIPTION
The Kitura-MustacheTemplateEngine repository currently doesn't have a Travis build defined. 
This PR adds a `.travis.yml` to address the issue to fall in line with the other Swift repos. 