### PR TITLE
Restore Swift 3.1 support, add Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Travis CI build file for Kitura-MustacheTemplateEngine.
 # Kitura runs on OS X and Linux (Ubuntu v14.04).
 
-# whitelist (branches that should be built)
+# whitelist (branches that should be built) 
 branches:
   only:
     - master
@@ -13,9 +13,26 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      env: SWIFT_SNAPSHOT=3.1.1
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
+    - os: osx
+      osx_image: xcode8.3
+      sudo: required
+      env: SWIFT_SNAPSHOT=3.1.1
     - os: osx
       osx_image: xcode9.2
       sudo: required
+    - os: osx
+      osx_image: xcode9.3beta
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
+
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Travis CI build file for Kitura-MustacheTemplateEngine.
 # Kitura runs on OS X and Linux (Ubuntu v14.04).
 
-# whitelist (branches that should be built) 
+# whitelist (branches that should be built)
 branches:
   only:
     - master

--- a/Package.pins
+++ b/Package.pins
@@ -1,0 +1,5 @@
+{
+  "autoPin": false,
+  "pins": [],
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corporation 2016
+ * Copyright IBM Corporation 2016, 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,5 @@
-// swift-tools-version:4.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
 /**
- * Copyright IBM Corporation 2016, 2018
+ * Copyright IBM Corporation 2016
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,23 +18,9 @@ import PackageDescription
 
 let package = Package(
     name: "KituraMustache",
-    products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(
-            name: "KituraMustache",
-            targets: ["KituraMustache"]
-        )
-    ],
-    dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "2.0.0"),
-        .package(url: "https://github.com/IBM-Swift/GRMustache.swift.git", from: "1.7.4")
-    ],
-    targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(
-            name: "KituraMustache",
-            dependencies: ["KituraTemplateEngine", "Mustache"]
-        )
-    ]
-)
+    dependencies: [.Package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", majorVersion: 1, minor: 7)])
+
+#if !os(Linux) || swift(>=3.1)
+    package.dependencies.append(.Package(url: "https://github.com/IBM-Swift/GRMustache.swift.git",
+                                         majorVersion: 1, minor: 7))
+#endif

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,43 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+/**
+ * Copyright IBM Corporation 2016, 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import PackageDescription
+
+let package = Package(
+    name: "KituraMustache",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "KituraMustache",
+            targets: ["KituraMustache"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/IBM-Swift/Kitura-TemplateEngine.git", from: "1.7.3"),
+        .package(url: "https://github.com/IBM-Swift/GRMustache.swift.git", from: "1.7.4")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "KituraMustache",
+            dependencies: ["KituraTemplateEngine", "Mustache"]
+        )
+    ]
+)


### PR DESCRIPTION
- Restore Swift 3 format Package.swift
- Rename Swift 4 Package.swift to `Package@swift-4.swift`, for Swift 4.1 support
- Adds 3.1.1 and 4.1 to Travis
- Raises the patch level dependency on Kitura-TemplateEngine to 1.7.3, required for Swift 4.1 support